### PR TITLE
Fix static linking with minimap2 subproject

### DIFF
--- a/third-party/bam_sort.c
+++ b/third-party/bam_sort.c
@@ -200,7 +200,7 @@ static inline int heap_lt(const heap1_t a, const heap1_t b)
     return a.idx > b.idx;
 }
 
-KSORT_INIT(heap, heap1_t, heap_lt)
+KSORT_INIT(bam_sort_heap, heap1_t, heap_lt)
 
 typedef struct merged_header
 {
@@ -1448,7 +1448,7 @@ int bam_merge_core2(int by_qname, char *sort_tag, const char *out, const char *m
     if (!(flag & MERGE_UNCOMP)) hts_set_threads(fpout, n_threads);
 
     // Begin the actual merge
-    ks_heapmake(heap, n, heap);
+    ks_heapmake(bam_sort_heap, n, heap);
     while (heap->pos != HEAP_EMPTY) {
         bam1_t *b = heap->entry.bam_record;
         if (flag & MERGE_RG) {
@@ -1481,7 +1481,7 @@ int bam_merge_core2(int by_qname, char *sort_tag, const char *out, const char *m
             print_error(cmd, "\"%s\" is truncated", fn[heap->i]);
             goto fail;
         }
-        ks_heapadjust(heap, 0, n, heap);
+        ks_heapadjust(bam_sort_heap, 0, n, heap);
     }
 
     // Clean up and close
@@ -1677,7 +1677,7 @@ static int bam_merge_simple(int by_qname, char *sort_tag, const char *out, const
     }
 
     // Now do the merge
-    ks_heapmake(heap, heap_size, heap);
+    ks_heapmake(bam_sort_heap, heap_size, heap);
     while (heap->pos != HEAP_EMPTY) {
         bam1_t *b = heap->entry.bam_record;
         if (sam_write1(fpout, hout, b) < 0) {
@@ -1690,7 +1690,7 @@ static int bam_merge_simple(int by_qname, char *sort_tag, const char *out, const
             print_error(cmd, "Error reading \"%s\" : %s", fn[heap->i], strerror(errno));
             goto fail;
         }
-        ks_heapadjust(heap, 0, heap_size, heap);
+        ks_heapadjust(bam_sort_heap, 0, heap_size, heap);
     }
     // Clean up and close
     for (i = 0; i < n; i++) {


### PR DESCRIPTION
Attempting to build pbmm2 statically fails with

```
[5/5] Linking target src/pbmm2.
FAILED: src/pbmm2 
[…]
duplicate symbol _ks_ksmall_heap in:
    src/25a6634@@pbmm2@exe/.._third-party_bam_sort.c.o
    subprojects/minimap2/libminimap2.a(map.c.o)
duplicate symbol _ks_heapmake_heap in:
    src/25a6634@@pbmm2@exe/.._third-party_bam_sort.c.o
    subprojects/minimap2/libminimap2.a(map.c.o)
ld: 2 duplicate symbols for architecture x86_64
```

This is because both source files use `KSORT_INIT` with the same `name`, namely `heap`.

https://github.com/lh3/minimap2/blob/1739a260fb044eded97b3271cd5204c79363fa76/map.c#L80

https://github.com/PacificBiosciences/pbmm2/blob/1fe348e8d4f39a61a77248e847b0628df97d9e6b/third-party/bam_sort.c#L203

Some klib facilities (e.g. `KHASH_INIT2` and `KHASH_DECLARE`) allow code to specify `static` and/or `extern` to control how the generated klib functions might be shared with or hidden from other translation units. Others, like `KSORT_INIT`, do not and don't even use `static`, and the onus is on the programmer to ensure that the names are different and they don't clash. (As is usual for klib, this is under-documented…)

This patch shows an example of renaming one of them so they're different. With this, pbmm2 can be built with the non-system libraries linked statically:

```
$ otool -L src/pbmm2 
src/pbmm2:
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/usr/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.5)
	/usr/lib/liblzma.5.dylib (compatibility version 6.0.0, current version 6.3.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
```

Of course a good citizen would leave HTSlib linked dynamically so it can be shared and updated as appropriate, but this would be useful for the other components that don't change independently.