### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ C. Align reads, sort on-the-fly, and create PBI
   $ pbmm2 align ref.fasta movie.subreadset.xml ref.movie.alignmentset.xml --sort
 
 D. Omit output file and stream BAM output to stdout
-  $ pbmm2 align hg38.mmi movie1.subreadset.xml | samtools sort > hg38.movie1.sorted.bam
+  $ pbmm2 align hg38.mmi movie1.subreadset.xml | samtools sort - > hg38.movie1.sorted.bam
 
 E. Align CCS fastq input and sort output
   $ pbmm2 align ref.fasta movie.Q20.fastq ref.movie.bam --preset CCS --sort --rg '@RG\tID:myid\tSM:mysample'


### PR DESCRIPTION
The example samtools sort command should not be `| samtools sort > output.bam`, it should be `| samtools sort - > output.bam`. The `-` is necessary to tell samtools to expect a stream.