### PR TITLE
Add option for minimap2 cs tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Usage: pbmm2 index [options] <ref.fa|xml> <out.mmi>
 The output argument is optional. If not provided, BAM output is streamed to stdout.
 ```
 Usage: pbmm2 align [options] <ref.fa|xml|mmi> <in.bam|xml|fa|fq> [out.aligned.bam|xml]
+
+ - Optional: --cstag, outputs minimap2 'cs' tag. See minimap2 manual for details. Default: false.
 ```
 
 #### Alignment Parallelization

--- a/include/pbmm2/MM2Settings.h
+++ b/include/pbmm2/MM2Settings.h
@@ -33,6 +33,7 @@ struct MM2Settings
     bool DisableHPC = false;
     bool NoTrimming = false;
     float LongJoinFlankRatio = -1;
+    bool OutCS = false;
     std::string EnforcedMapping;
 };
 }  // namespace minimap2

--- a/src/AlignSettings.cpp
+++ b/src/AlignSettings.cpp
@@ -408,7 +408,7 @@ R"({
     "required" : false
 })"};
 
-const CLI_v2::Option NoSpliceFlank{
+const CLI_v2::Option OutCS{
 R"({
     "names" : ["cstag"],
     "description" : "Output minimap2 cs tag."

--- a/src/AlignSettings.cpp
+++ b/src/AlignSettings.cpp
@@ -408,6 +408,12 @@ R"({
     "required" : false
 })"};
 
+const CLI_v2::Option NoSpliceFlank{
+R"({
+    "names" : ["cstag"],
+    "description" : "Output minimap2 cs tag."
+})"};
+
 // clang-format on
 }  // namespace OptionNames
 
@@ -451,6 +457,7 @@ AlignSettings::AlignSettings(const PacBio::CLI_v2::Results& options)
     MM2Settings::MaxNumAlns = options[OptionNames::MaxNumAlns];
     MM2Settings::MaxGap = options[OptionNames::MaxGap];
     MM2Settings::EnforcedMapping = std::string(options[OptionNames::EnforcedMapping]);
+    MM2Settings::OutCS = options[OptionNames::OutCS];
     if (!MM2Settings::EnforcedMapping.empty()) MM2Settings::NoTrimming = true;
     MM2Settings::MaxSecondaryAlns = options[OptionNames::MaxSecondaryAlns];
 
@@ -703,6 +710,7 @@ PacBio::CLI_v2::Interface AlignSettings::CreateCLI()
         OptionNames::OutputUnmapped,
         OptionNames::BamIndexInput,
         OptionNames::NoBAI,
+        OptionNames::OutCS,
     });
 
     i.AddOptionGroup("Input Manipulation Options (mutually exclusive)", {

--- a/src/MM2Helper.cpp
+++ b/src/MM2Helper.cpp
@@ -191,6 +191,9 @@ void MM2Helper::PreInit(const MM2Settings& settings, std::string* preset)
     }
     MapOpts.min_join_flank_ratio = 0.5;
 
+    //Allow for optional minimap2 'cs' tag
+    if (settings.OutCS) MapOpts.flag |= MM_F_OUT_CS;
+
     switch (settings.AlignMode) {
         case AlignmentMode::SUBREADS:
             *preset = "SUBREADS";

--- a/tests/cram/cstag.t
+++ b/tests/cram/cstag.t
@@ -1,0 +1,6 @@
+  $ IN=$TESTDIR/data/median.bam
+  $ REF=$TESTDIR/data/ecoliK12_pbi_March2013.fasta
+
+  $ $__PBTEST_PBMM2_EXE align $IN $REF $CRAMTMP/aligned.bam --cstag
+  $ samtools view $CRAMTMP/aligned.bam | head -n 1 | grep -c '\tcs:'
+  1


### PR DESCRIPTION
The minimap2 cs tag can be very useful for quickly determining the reference and query bases for mismatches and indels, without having to look up positions in the reference.

This pull request adds a --cstag to pbmm2 that activates the minimap2 'cs tag' output option.