### PR TITLE
Support .fna extension  for FASTA

### DIFF
--- a/src/InputOutputUX.cpp
+++ b/src/InputOutputUX.cpp
@@ -27,9 +27,11 @@ InputType DetermineInputFileSuffix(const std::string& inputFile)
         boost::iends_with(inputFile, "fq.gz") || boost::iends_with(inputFile, "fastq.gz"))
         return InputType::FASTQ;
 
-    if (boost::iends_with(inputFile, "fa") || boost::iends_with(inputFile, "fasta") ||
-        boost::iends_with(inputFile, "fa.gz") || boost::iends_with(inputFile, "fasta.gz") ||
-        boost::iends_with(inputFile, "fsa"))
+    if (
+            boost::iends_with(inputFile, "fa") || boost::iends_with(inputFile, "fasta") || boost::iends_with(inputFile, "fna") ||
+            boost::iends_with(inputFile, "fa.gz") || boost::iends_with(inputFile, "fasta.gz") || boost::iends_with(inputFile, "fna.gz") ||
+            boost::iends_with(inputFile, "fsa")
+        )
         return InputType::FASTA;
 
     if (boost::iends_with(inputFile, "bam")) return InputType::BAM;


### PR DESCRIPTION
Hi there!

Since we can't open any issues, I thought to try my hand at fixing this myself. There are my very first lines of C code, so I don't have a clue if this is up to par.

This PR should add support for fasta files with an `fna` extension, both compressed and uncompressed.

xref https://github.com/nf-core/pacvar/issues/16

Cheers
Matthias