### PR TITLE
Fix compile error, improve error message and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,16 @@ with the same input parameters. The same can occur even with option `--sort` for
 records that align to the same target sequence, the same position within that target,
 and in the same orientation, which are the only fields that `samtools sort` uses.
 
+## How to build
+
+Install [meson](https://mesonbuild.com) and run:
+
+```shell
+meson build -Dtests=false # Not all test dependencies are publicly available
+cd build/
+ninja
+```
+
 ## Full Changelog
 
  * 1.17.0

--- a/src/AlignWorkflow.cpp
+++ b/src/AlignWorkflow.cpp
@@ -247,8 +247,8 @@ int AlignWorkflow::Runner(const CLI_v2::Results& options)
                         }
                     }
                 }
-            } catch (...) {
-                std::cerr << "ERROR" << std::endl;
+            } catch (const std::exception& ex) {
+                std::cerr << "ERROR: " << ex.what() << std::endl;
             }
             waiting--;
         };

--- a/src/MM2Helper.cpp
+++ b/src/MM2Helper.cpp
@@ -951,7 +951,7 @@ std::vector<Out> MM2Helper::AlignImpl(const In& record,
                 sa << Idx->idx_->seq[rec.ReferenceId()].name << ',' << qrs + 1 << ',' << "+-"[qrev]
                    << ',';
 
-                sa << Data::ToStdString(rec.CigarData());
+                sa << rec.CigarData().ToStdString();
 
                 sa << ',' << static_cast<int>(rec.MapQuality()) << ',' << rec.NumMismatches()
                    << ';';


### PR DESCRIPTION
This adds brief instructions on how to build `pbmm2` (in particular, which flags need to be set to build it as an external user) to the README, and improves the error message that is printed when e.g. `mm2helper->Align(...)` is throwing an exception.

Two other points (raising them here as GitHub issues are not enabled for the project):

- I've noticed that this builds version `1.13.1` (not `1.17.0`); is there any way to build a newer version locally?

- Sometimes it is preferable to fail early when the aligner throws exceptions (e.g. because of invalid BAM tags). Right now these errors are printed out but the program continues and returns the non-error code `0`. Maybe we could add a `--strict` option to control this?